### PR TITLE
Add an option to supply module-specific options from a file

### DIFF
--- a/src/pppoat.c
+++ b/src/pppoat.c
@@ -60,6 +60,8 @@ static void help_print(FILE *f, char *name)
 	fprintf(f, "Options:\n"
 		   "  --dest=<ip> (-d)     Destination IP for the tunnel\n"
 		   "  --help (-h)          Print this help\n"
+		   "  --config (-c)        Path to file with module-specific options\n"
+		   "                       (Each option must be on a dedicated line.)\n"
 		   "  --if=<name> (-i)     Interface module name\n"
 		   "  --list (-l)          Print list of available modules\n"
 		   "  --module=<name> (-m) Transport module name\n"


### PR DESCRIPTION
This in particular allows to avoid passing the password via command
line, which would otherwise not only easy to forget in the shell
history, but also be visible in `ps` output.